### PR TITLE
Don't minify javascript and CSS

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,10 +13,8 @@ gem 'rotp'
 gem 'sass'
 gem 'sprockets', '2.12.1'
 gem 'sprockets-rails', :require => 'sprockets/railtie', :git => 'https://github.com/ryanjohns/sprockets-rails'
-gem 'uglifier'
 gem 'unicorn'
 gem 'uuidtools'
-gem 'yui-compressor'
 gem 'zipruby'
 
 group :development, :staging do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -43,7 +43,6 @@ GEM
       nokogiri (>= 1.4.4)
     builder (3.2.2)
     erubis (2.7.0)
-    execjs (2.2.1)
     factory_girl (4.4.0)
       activesupport (>= 3.0.0)
     factory_girl_rails (4.4.1)
@@ -118,15 +117,11 @@ GEM
       polyglot (>= 0.3.1)
     tzinfo (1.2.1)
       thread_safe (~> 0.1)
-    uglifier (2.5.3)
-      execjs (>= 0.3.0)
-      json (>= 1.8.0)
     unicorn (4.8.3)
       kgio (~> 2.6)
       rack
       raindrops (~> 0.7)
     uuidtools (2.1.4)
-    yui-compressor (0.12.0)
     zipruby (0.3.6)
 
 PLATFORMS
@@ -147,8 +142,6 @@ DEPENDENCIES
   sass
   sprockets (= 2.12.1)
   sprockets-rails!
-  uglifier
   unicorn
   uuidtools
-  yui-compressor
   zipruby

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -22,10 +22,6 @@ Rails.application.configure do
   # Disable Rails's static asset server (Apache or nginx will already do this).
   config.serve_static_assets = false
 
-  # Compress JavaScripts and CSS.
-  config.assets.js_compressor = :uglifier
-  config.assets.css_compressor = :yui
-
   # Do not fallback to assets pipeline if a precompiled asset is missed.
   config.assets.compile = false
 

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -22,10 +22,6 @@ Rails.application.configure do
   # Disable Rails's static asset server (Apache or nginx will already do this).
   config.serve_static_assets = false
 
-  # Compress JavaScripts and CSS.
-  config.assets.js_compressor = :uglifier
-  config.assets.css_compressor = :yui
-
   # Do not fallback to assets pipeline if a precompiled asset is missed.
   config.assets.compile = false
 


### PR DESCRIPTION
No longer minify javascript and CSS. This should make it easier to view source and see that the JS being served is legit. Also removes gem dependencies on ugliifier and yui-compressor.
