### PR TITLE
Generate passwords more uniformly

### DIFF
--- a/app/assets/javascripts/passwords.js
+++ b/app/assets/javascripts/passwords.js
@@ -5,7 +5,10 @@
     var password = '';
     var rand;
     while (i < length) {
-      rand = (Math.abs(sjcl.random.randomWords(1)[0] % 100) % 94) + 33;
+      rand = Math.abs(sjcl.random.randomWords(1)[0]) % 128;
+      if (rand < 33 || rand > 126) {
+        continue;
+      }
       if (!special) {
         if ((rand >= 33 && rand <= 47) ||
             (rand >= 58 && rand <= 64) ||


### PR DESCRIPTION
The current password generation method will ever-so-slightly favor certain characters since randomWords() returns a number between -2^31 and 2^31, but is being modded by 94. Modding it by 128 and throwing away invalid values solves this.
