### PR TITLE
html-escape passwords in accounts_viewer (backups)

### DIFF
--- a/app/views/application/accounts_viewer.html.haml
+++ b/app/views/application/accounts_viewer.html.haml
@@ -95,7 +95,14 @@
 
           html += '<tr>';
           for (var i = 0; i < columns.length; i++) {
-            html += '<td><pre>' + accounts[accountId][columns[i]] + '</pre></td>';
+            var str = accounts[accountId][columns[i]];
+
+            // html-escape the string
+            var div = document.createElement('div');
+            div.appendChild(document.createTextNode(str));
+            var escaped_str = div.innerHTML;
+
+            html += '<td><pre>' + escaped_str + '</pre></td>';
           }
           html += '</tr>';
         }

--- a/public/accounts_viewer.html
+++ b/public/accounts_viewer.html
@@ -94,7 +94,14 @@
 
           html += '<tr>';
           for (var i = 0; i < columns.length; i++) {
-            html += '<td><pre>' + accounts[accountId][columns[i]] + '</pre></td>';
+            var str = accounts[accountId][columns[i]];
+
+            // html-escape the string
+            var div = document.createElement('div');
+            div.appendChild(document.createTextNode(str));
+            var escaped_str = div.innerHTML;
+
+            html += '<td><pre>' + escaped_str + '</pre></td>';
           }
           html += '</tr>';
         }


### PR DESCRIPTION
To recreate the issue, try using password "abc123&lt;I456" (the "&lt;I" part gets treated as an `<i>` tag without escaping it).

Note: One hangup I ran into when testing was that the ACCOUNTS_VIEWER (the file object) gets set in an initializer, so unicorn needs to be restarted after changes are made to accounts_viewer.html